### PR TITLE
Improve ConfigurationItem comparison

### DIFF
--- a/xldeploy.py
+++ b/xldeploy.py
@@ -124,11 +124,14 @@ class ConfigurationItem:
         #    return False
 
         for k, v in item.properties.iteritems():
-            # return false unless is.has_key? k and is[k]==@should.first[k].to_s
             if k not in self.properties:
                 return False
-            if not self.properties[k] == v:
-                return False
+            if type(self.properties[k]) is str:
+                if not str(self.properties[k]) == str(v):
+                    return False
+            elif type(self.properties[k]) is list:
+                if not set(v).issubset(set(self.properties[k])):
+                    return False
 
         return True
 


### PR DESCRIPTION
This improves the __contains__ method in two ways:
- Compare plain properties as strings, because xl-deploy will store it as string anyway and it would always report as changed if one of the provided parameters is int().
- See if the new list parameter is a subset of existing list parameter rather that requiring identical values

Overall this should avoid reporting changed=True in cases where this isn't really the case. 
