### PR TITLE
Fix bug in xldeploy.py preventing some CI updates

### DIFF
--- a/xldeploy.py
+++ b/xldeploy.py
@@ -304,19 +304,19 @@ def main():
         elif state == 'present':
             if repository.exists(ci_id):
                 existing_ci = repository.read(ci_id)
-                if ci in existing_ci:
-                    module.exit_json(changed=False)
+                update_mode = module.params.get('update_mode')
+                if update_mode == 'replace':
+                    msg = "[REPLACE] Update %s, previous %s" % (
+                        ci, existing_ci)
+                    repository.update(ci)
                 else:
-                    update_mode = module.params.get('update_mode')
-                    if update_mode == 'replace':
-                        msg = "[REPLACE] Update %s, previous %s" % (
-                            ci, existing_ci)
-                        repository.update(ci)
+                    if ci in existing_ci:
+                        module.exit_json(changed=False)
                     else:
                         msg = "[ADD] Update %s, previous %s" % (ci,
                                                                 existing_ci)
-                        existing_ci.update_with(ci)
-                        repository.update(existing_ci)
+                    existing_ci.update_with(ci)
+                    repository.update(existing_ci)
             else:
                 msg = "Create %s" % ci
                 repository.create(ci)


### PR DESCRIPTION
This fix allows to update CI when new properties are subsets of current properties, if `update_mode=replace`.

Currently, CI are not updated in such a case. For example, one would expect the following task to replace the existing CI and remove its containers (if any), where it actually leaves it unchanged :

```yaml
- name: Remove infrastructure containers from environment
  xldeploy:
    id: Environments/others/tomcat-test
    type: udm.Environment
    endpoint: http://10.0.2.2:4516
    username: xldeployuser
    password: MySuperS3cr3tPassw0rd
    validate_certs: False
    update_mode: replace
    properties:
      members: []
```

The current downside of this fix is that tasks are not idempotent anymore when `update_mode=replace`. Objects are always replaced.
